### PR TITLE
Add support for IDv3 and operator v2 APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ shell:
 examples: example_client example_auto_refresh example_encryption
 
 example_client:
-	docker run -w $(PWD) -v $(PWD):$(PWD) -u `id -u`:`id -g` -e PYTHONPATH=$(PWD) $(DOCKERIMAGE) python3 examples/sample_client.py "$(BASE_URL)" "$(AUTH_KEY)" "$(AD_TOKEN)"
+	docker run -w $(PWD) -v $(PWD):$(PWD) -u `id -u`:`id -g` -e PYTHONPATH=$(PWD) $(DOCKERIMAGE) python3 examples/sample_client.py "$(BASE_URL)" "$(AUTH_KEY)" "$(SECRET_KEY)" "$(AD_TOKEN)"
 
 example_auto_refresh:
-	docker run -w $(PWD) -v $(PWD):$(PWD) -u `id -u`:`id -g` -e PYTHONPATH=$(PWD) $(DOCKERIMAGE) python3 examples/sample_auto_refresh.py "$(BASE_URL)" "$(AUTH_KEY)" "$(AD_TOKEN)"
+	docker run -w $(PWD) -v $(PWD):$(PWD) -u `id -u`:`id -g` -e PYTHONPATH=$(PWD) $(DOCKERIMAGE) python3 examples/sample_auto_refresh.py "$(BASE_URL)" "$(AUTH_KEY)" "$(SECRET_KEY)" "$(AD_TOKEN)"
 
 example_encryption:
-	docker run -w $(PWD) -v $(PWD):$(PWD) -u `id -u`:`id -g` -e PYTHONPATH=$(PWD) $(DOCKERIMAGE) python3 examples/sample_encryption.py "$(BASE_URL)" "$(AUTH_KEY)" "$(AD_TOKEN)" "Hello World!"
+	docker run -w $(PWD) -v $(PWD):$(PWD) -u `id -u`:`id -g` -e PYTHONPATH=$(PWD) $(DOCKERIMAGE) python3 examples/sample_encryption.py "$(BASE_URL)" "$(AUTH_KEY)" "$(SECRET_KEY)" "$(AD_TOKEN)" "Hello World!"
 
 docker:
 	docker build -t $(DOCKERIMAGE) -f Dockerfile.dev .

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ from an advertising token:
 ```
 from uid2_client import Uid2Client, decrypt_token
 
-client = Uid2Client('https://prod.uidapi.com', 'my-auth-token')
+client = Uid2Client('https://prod.uidapi.com', 'my-auth-token', 'my-secret-key')
 keys = client.refresh_keys()
 advertising_token = 'AgAAAANRdREk+IWqqnQkZ2rZdK0TgSUP/owLryysSkUGZJT+Gy551L1WJMAZA/G2B1UMDQ20WAqwwTu6o9TexWyux0lg0HHIbmJjN6IYwo+42KC8ugaR+PX0y18qQ+3yzkxmJ/ee//4IGu/1Yq4AmO4ArXN6CeszPTxByTkysVqyQVNY2A=='
 decrypted_token = decrypt_token(advertising_token, keys)
@@ -52,16 +52,16 @@ make shell
 Run all the example applications:
 
 ```
-make examples BASE_URL=https://prod.uidapi.com AUTH_KEY=my-auth-key \
+make examples BASE_URL=https://prod.uidapi.com AUTH_KEY=my-auth-key SECRET_KEY=my-secret-key \
 	AD_TOKEN=AgAAAANRdREk+IWqqnQkZ2rZdK0TgSUP/owLryysSkUGZJT+Gy551L1WJMAZA/G2B1UMDQ20WAqwwTu6o9TexWyux0lg0HHIbmJjN6IYwo+42KC8ugaR+PX0y18qQ+3yzkxmJ/ee//4IGu/1Yq4AmO4ArXN6CeszPTxByTkysVqyQVNY2A==
 ```
 
 Or specific examples:
 
 ```
-make example_client BASE_URL=https://prod.uidapi.com AUTH_KEY=my-auth-key \
+make example_client BASE_URL=https://prod.uidapi.com AUTH_KEY=my-auth-key SECRET_KEY=my-secret-key \
 	AD_TOKEN=AgAAAANRdREk+IWqqnQkZ2rZdK0TgSUP/owLryysSkUGZJT+Gy551L1WJMAZA/G2B1UMDQ20WAqwwTu6o9TexWyux0lg0HHIbmJjN6IYwo+42KC8ugaR+PX0y18qQ+3yzkxmJ/ee//4IGu/1Yq4AmO4ArXN6CeszPTxByTkysVqyQVNY2A==
-make example_auto_refresh BASE_URL=https://prod.uidapi.com AUTH_KEY=my-auth-key \
+make example_auto_refresh BASE_URL=https://prod.uidapi.com AUTH_KEY=my-auth-key SECRET_KEY=my-secret-key \
 	AD_TOKEN=AgAAAANRdREk+IWqqnQkZ2rZdK0TgSUP/owLryysSkUGZJT+Gy551L1WJMAZA/G2B1UMDQ20WAqwwTu6o9TexWyux0lg0HHIbmJjN6IYwo+42KC8ugaR+PX0y18qQ+3yzkxmJ/ee//4IGu/1Yq4AmO4ArXN6CeszPTxByTkysVqyQVNY2A==
 ```
 

--- a/examples/sample_auto_refresh.py
+++ b/examples/sample_auto_refresh.py
@@ -31,18 +31,19 @@ from uid2_client import decrypt_token
 
 
 def _usage():
-    print('Usage: python3 sample_auto_refresh.py <base_url> <auth_key> <ad_token>', file=sys.stderr)
+    print('Usage: python3 sample_auto_refresh.py <base_url> <auth_key> <secret_key> <ad_token>', file=sys.stderr)
     sys.exit(1)
 
 
-if len(sys.argv) <= 3:
+if len(sys.argv) <= 4:
     _usage()
 
 base_url = sys.argv[1]
 auth_key = sys.argv[2]
-ad_token = sys.argv[3]
+secret_key = sys.argv[3]
+ad_token = sys.argv[4]
 
-client = Uid2Client(base_url, auth_key)
+client = Uid2Client(base_url, auth_key, secret_key)
 with EncryptionKeysAutoRefresher(client, dt.timedelta(seconds=4), dt.timedelta(seconds=7)) as refresher:
     for i in range(0, 20):
         refresh_result = refresher.current_result()

--- a/examples/sample_client.py
+++ b/examples/sample_client.py
@@ -28,20 +28,22 @@ from uid2_client import decrypt_token
 
 
 def _usage():
-    print('Usage: python3 sample_client.py <base_url> <auth_key> <ad_token>', file=sys.stderr)
+    print('Usage: python3 sample_client.py <base_url> <auth_key> <secret_key> <ad_token>', file=sys.stderr)
     sys.exit(1)
 
 
-if len(sys.argv) <= 3:
+if len(sys.argv) <= 4:
     _usage()
 
 base_url = sys.argv[1]
 auth_key = sys.argv[2]
-ad_token = sys.argv[3]
+secret_key = sys.argv[3]
+ad_token = sys.argv[4]
 
-client = Uid2Client(base_url, auth_key)
+client = Uid2Client(base_url, auth_key, secret_key)
 keys = client.refresh_keys()
 result = decrypt_token(ad_token, keys)
 
 print('UID2 =', result.uid2)
-print('Established = ', result.established)
+print('Established =', result.established)
+print('Site ID =', result.site_id)

--- a/examples/sample_encryption.py
+++ b/examples/sample_encryption.py
@@ -24,30 +24,31 @@
 import base64
 import sys
 
-from uid2_client import Uid2Client
+from uid2_client import Uid2Client, IdentityScope
 from uid2_client import encrypt_data, decrypt_data
 
 
 def _usage():
-    print('Usage: python3 sample_encryption.py <base_url> <auth_key> <ad_token> <data>', file=sys.stderr)
+    print('Usage: python3 sample_encryption.py <base_url> <auth_key> <secret_key> <ad_token> <data>', file=sys.stderr)
     sys.exit(1)
 
 
-if len(sys.argv) <= 3:
+if len(sys.argv) <= 5:
     _usage()
 
 base_url = sys.argv[1]
 auth_key = sys.argv[2]
-ad_token = sys.argv[3]
-str_data = sys.argv[4]
+secret_key = sys.argv[3]
+ad_token = sys.argv[4]
+str_data = sys.argv[5]
 
-client = Uid2Client(base_url, auth_key)
+client = Uid2Client(base_url, auth_key, secret_key)
 keys = client.refresh_keys()
 
 data = bytes(str_data, 'utf-8')
-encrypted = encrypt_data(data, keys=keys, advertising_token=ad_token)
+encrypted = encrypt_data(data, IdentityScope.UID2, keys=keys, advertising_token=ad_token)
 decrypted = decrypt_data(encrypted, keys)
 
-print('Encrypted = ', encrypted)
+print('Encrypted =', encrypted)
 print('Decrypted =', decrypted.data)
-print('Encrypted at (UTC) = ', decrypted.encrypted_at)
+print('Encrypted at (UTC) =', decrypted.encrypted_at)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = uid2-client
-version = 1.0.0
+version = 2.0.0
 author = Andrei Tarassov
 author_email = andrei.tarassov@thetradedesk.com
 home_page = http://www.thetradedesk.com

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -23,11 +23,12 @@
 
 import base64
 import datetime as dt
+import os
 import unittest
 from Crypto.Cipher import AES
 
-from uid2_client import decrypt_token, encrypt_data, decrypt_data, encryption_block_size, EncryptionError
-from uid2_client.encryption import _encrypt_data_v1
+from uid2_client import decrypt_token, encrypt_data, decrypt_data, encryption_block_size, EncryptionError, IdentityScope
+from uid2_client.encryption import _encrypt_data_v1, _encrypt_gcm, _PayloadType
 from uid2_client.keys import *
 
 
@@ -48,7 +49,7 @@ _test_site_key = EncryptionKey(_test_site_key_id, _site_id, dt.datetime(2020, 1,
 class TestEncryptionFunctions(unittest.TestCase):
 
     def test_decrypt_token(self):
-        token = _encrypt_token(_uid2, _master_key, _site_key)
+        token = _encrypt_token_v3(_uid2, _master_key, _site_key)
 
         keys = EncryptionKeysCollection([_master_key, _site_key])
         result = decrypt_token(token, keys)
@@ -57,7 +58,7 @@ class TestEncryptionFunctions(unittest.TestCase):
 
 
     def test_decrypt_token_empty_keys(self):
-        token = _encrypt_token(_uid2, _master_key, _site_key)
+        token = _encrypt_token_v3(_uid2, _master_key, _site_key)
 
         keys = EncryptionKeysCollection([])
 
@@ -66,7 +67,7 @@ class TestEncryptionFunctions(unittest.TestCase):
 
 
     def test_decrypt_token_no_master_key(self):
-        token = _encrypt_token(_uid2, _master_key, _site_key)
+        token = _encrypt_token_v3(_uid2, _master_key, _site_key)
 
         keys = EncryptionKeysCollection([_site_key])
 
@@ -75,7 +76,7 @@ class TestEncryptionFunctions(unittest.TestCase):
 
 
     def test_decrypt_token_no_site_key(self):
-        token = _encrypt_token(_uid2, _master_key, _site_key)
+        token = _encrypt_token_v3(_uid2, _master_key, _site_key)
 
         keys = EncryptionKeysCollection([_master_key])
 
@@ -84,7 +85,7 @@ class TestEncryptionFunctions(unittest.TestCase):
 
 
     def test_decrypt_token_invalid_version(self):
-        token = _encrypt_token(_uid2, _master_key, _site_key, version=1)
+        token = _encrypt_token_v3(_uid2, _master_key, _site_key, version=1)
 
         keys = EncryptionKeysCollection([_master_key, _site_key])
 
@@ -93,7 +94,7 @@ class TestEncryptionFunctions(unittest.TestCase):
 
 
     def test_decrypt_token_expired(self):
-        token = _encrypt_token(_uid2, _master_key, _site_key, expiry=dt.timedelta(seconds=-1))
+        token = _encrypt_token_v3(_uid2, _master_key, _site_key, expiry=dt.timedelta(seconds=-1))
 
         keys = EncryptionKeysCollection([_master_key, _site_key])
 
@@ -103,7 +104,7 @@ class TestEncryptionFunctions(unittest.TestCase):
 
     def test_decrypt_token_custom_now(self):
         expiry = dt.datetime(2021, 3, 22, 9, 1, 2)
-        token = _encrypt_token(_uid2, _master_key, _site_key, expiry=expiry)
+        token = _encrypt_token_v3(_uid2, _master_key, _site_key, expiry=expiry)
 
         keys = EncryptionKeysCollection([_master_key, _site_key])
 
@@ -115,7 +116,83 @@ class TestEncryptionFunctions(unittest.TestCase):
 
 
     def test_decrypt_token_invalid_payload(self):
-        token = _encrypt_token(_uid2, _master_key, _site_key, expiry=dt.timedelta(seconds=-1))
+        token = _encrypt_token_v3(_uid2, _master_key, _site_key, expiry=dt.timedelta(seconds=-1))
+
+        keys = EncryptionKeysCollection([_master_key, _site_key])
+
+        with self.assertRaises(EncryptionError):
+            result = decrypt_token(token[:-3], keys)
+
+
+    def test_decrypt_token_v2(self):
+        token = _encrypt_token_v2(_uid2, _master_key, _site_key)
+
+        keys = EncryptionKeysCollection([_master_key, _site_key])
+        result = decrypt_token(token, keys)
+
+        self.assertEqual(_uid2, result.uid2)
+
+
+    def test_decrypt_token_v2_empty_keys(self):
+        token = _encrypt_token_v2(_uid2, _master_key, _site_key)
+
+        keys = EncryptionKeysCollection([])
+
+        with self.assertRaises(EncryptionError):
+            result = decrypt_token(token, keys)
+
+
+    def test_decrypt_token_v2_no_master_key(self):
+        token = _encrypt_token_v2(_uid2, _master_key, _site_key)
+
+        keys = EncryptionKeysCollection([_site_key])
+
+        with self.assertRaises(EncryptionError):
+            result = decrypt_token(token, keys)
+
+
+    def test_decrypt_token_v2_no_site_key(self):
+        token = _encrypt_token_v2(_uid2, _master_key, _site_key)
+
+        keys = EncryptionKeysCollection([_master_key])
+
+        with self.assertRaises(EncryptionError):
+            result = decrypt_token(token, keys)
+
+
+    def test_decrypt_token_v2_invalid_version(self):
+        token = _encrypt_token_v2(_uid2, _master_key, _site_key, version=1)
+
+        keys = EncryptionKeysCollection([_master_key, _site_key])
+
+        with self.assertRaises(EncryptionError):
+            result = decrypt_token(token, keys)
+
+
+    def test_decrypt_token_v2_expired(self):
+        token = _encrypt_token_v2(_uid2, _master_key, _site_key, expiry=dt.timedelta(seconds=-1))
+
+        keys = EncryptionKeysCollection([_master_key, _site_key])
+
+        with self.assertRaises(EncryptionError):
+            result = decrypt_token(token, keys)
+
+
+    def test_decrypt_token_v2_custom_now(self):
+        expiry = dt.datetime(2021, 3, 22, 9, 1, 2)
+        token = _encrypt_token_v2(_uid2, _master_key, _site_key, expiry=expiry)
+
+        keys = EncryptionKeysCollection([_master_key, _site_key])
+
+        with self.assertRaises(EncryptionError):
+            result = decrypt_token(token, keys, now=expiry+dt.timedelta(seconds=1))
+
+        result = decrypt_token(token, keys, now=expiry-dt.timedelta(seconds=1))
+        self.assertEqual(_uid2, result.uid2)
+
+
+    def test_decrypt_token_v2_invalid_payload(self):
+        token = _encrypt_token_v2(_uid2, _master_key, _site_key, expiry=dt.timedelta(seconds=-1))
 
         keys = EncryptionKeysCollection([_master_key, _site_key])
 
@@ -125,10 +202,10 @@ class TestEncryptionFunctions(unittest.TestCase):
 
     def test_encrypt_data_specific_key_and_iv(self):
         data = b'123456'
-        iv = encryption_block_size * b'0'
+        iv = 12 * b'0'
         key = _test_site_key
         keys = EncryptionKeysCollection([key])
-        encrypted = encrypt_data(data, iv=iv, key=key)
+        encrypted = encrypt_data(data, IdentityScope.UID2, iv=iv, key=key)
         self.assertTrue(len(data) + len(iv) < len(encrypted))
         decrypted = decrypt_data(encrypted, keys)
         self.assertEqual(data, decrypted.data)
@@ -138,7 +215,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         data = b'123456'
         key = _test_site_key
         keys = EncryptionKeysCollection([key])
-        encrypted = encrypt_data(data, key=key)
+        encrypted = encrypt_data(data, IdentityScope.UID2, key=key)
         self.assertTrue(len(data) + encryption_block_size < len(encrypted))
         decrypted = decrypt_data(encrypted, keys)
         self.assertEqual(data, decrypted.data)
@@ -148,7 +225,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         data = b'123456'
         key = _test_site_key
         keys = EncryptionKeysCollection([key])
-        encrypted = encrypt_data(data, site_id=key.site_id, keys=keys)
+        encrypted = encrypt_data(data, IdentityScope.UID2, site_id=key.site_id, keys=keys)
         self.assertTrue(len(data) + encryption_block_size < len(encrypted))
         decrypted = decrypt_data(encrypted, keys)
         self.assertEqual(data, decrypted.data)
@@ -158,8 +235,8 @@ class TestEncryptionFunctions(unittest.TestCase):
         data = b'123456'
         key = _test_site_key
         keys = EncryptionKeysCollection([_master_key, key])
-        token = _encrypt_token(_uid2, _master_key, key, site_id=key.site_id)
-        encrypted = encrypt_data(data, advertising_token=token, keys=keys)
+        token = _encrypt_token_v3(_uid2, _master_key, key, site_id=key.site_id)
+        encrypted = encrypt_data(data, IdentityScope.UID2, advertising_token=token, keys=keys)
         self.assertTrue(len(data) + encryption_block_size < len(encrypted))
         decrypted = decrypt_data(encrypted, keys)
         self.assertEqual(data, decrypted.data)
@@ -170,16 +247,16 @@ class TestEncryptionFunctions(unittest.TestCase):
         key = _test_site_key
         keys = EncryptionKeysCollection([key])
         with self.assertRaises(ValueError):
-            encrypt_data(data, key=key, keys=keys)
+            encrypt_data(data, IdentityScope.UID2, key=key, keys=keys)
 
 
     def test_encrypt_data_site_id_and_token_set(self):
         data = b'123456'
         key = _test_site_key
         keys = EncryptionKeysCollection([_master_key, key])
-        token = _encrypt_token(_uid2, _master_key, key, site_id=key.site_id)
+        token = _encrypt_token_v3(_uid2, _master_key, key, site_id=key.site_id)
         with self.assertRaises(ValueError):
-            encrypt_data(data, keys=keys, site_id=key.site_id, advertising_token=token)
+            encrypt_data(data, IdentityScope.UID2, keys=keys, site_id=key.site_id, advertising_token=token)
 
 
     def test_encrypt_data_token_decrypt_failed(self):
@@ -187,7 +264,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         key = _test_site_key
         keys = EncryptionKeysCollection([_master_key, _test_site_key])
         with self.assertRaises(EncryptionError):
-            encrypt_data(data, keys=keys, advertising_token="bogus-token")
+            encrypt_data(data, IdentityScope.UID2, keys=keys, advertising_token="bogus-token")
 
 
     def test_encrypt_data_key_expired(self):
@@ -195,7 +272,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         site_id = 205
         key = EncryptionKey(101, site_id, _now - dt.timedelta(days=2), _now - dt.timedelta(days=2), _now - dt.timedelta(days=1), encryption_block_size * b'9')
         with self.assertRaises(EncryptionError):
-            encrypt_data(data, key=key)
+            encrypt_data(data, IdentityScope.UID2, key=key)
 
 
     def test_encrypt_data_key_inactive(self):
@@ -203,7 +280,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         site_id = 205
         key = EncryptionKey(101, site_id, _now - dt.timedelta(days=2), _now + dt.timedelta(days=2), _now + dt.timedelta(days=3), encryption_block_size * b'9')
         with self.assertRaises(EncryptionError):
-            encrypt_data(data, key=key)
+            encrypt_data(data, IdentityScope.UID2, key=key)
 
 
     def test_encrypt_data_key_expired_custom_now(self):
@@ -211,7 +288,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         key = _test_site_key
         now = _test_site_key.expires
         with self.assertRaises(EncryptionError):
-            encrypt_data(data, key=key, now=now)
+            encrypt_data(data, IdentityScope.UID2, key=key, now=now)
 
 
     def test_encrypt_data_key_inactive_custom_now(self):
@@ -219,14 +296,14 @@ class TestEncryptionFunctions(unittest.TestCase):
         key = _test_site_key
         now = _test_site_key.activates - dt.timedelta(seconds=1)
         with self.assertRaises(EncryptionError):
-            encrypt_data(data, key=key, now=now)
+            encrypt_data(data, IdentityScope.UID2, key=key, now=now)
 
 
     def test_encrypt_data_no_site_key(self):
         data = b'123456'
         keys = EncryptionKeysCollection([_master_key])
         with self.assertRaises(EncryptionError):
-            encrypt_data(data, keys=keys, site_id=205)
+            encrypt_data(data, IdentityScope.UID2, keys=keys, site_id=205)
 
 
     def test_encrypt_data_site_key_expired(self):
@@ -235,7 +312,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         key = EncryptionKey(101, site_id, _now - dt.timedelta(days=2), _now - dt.timedelta(days=2), _now - dt.timedelta(days=1), encryption_block_size * b'9')
         keys = EncryptionKeysCollection([key])
         with self.assertRaises(EncryptionError):
-            encrypt_data(data, keys=keys, site_id=site_id)
+            encrypt_data(data, IdentityScope.UID2, keys=keys, site_id=site_id)
 
 
     def test_encrypt_data_site_key_inactive(self):
@@ -244,7 +321,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         key = EncryptionKey(101, site_id, _now - dt.timedelta(days=2), _now + dt.timedelta(days=2), _now + dt.timedelta(days=3), encryption_block_size * b'9')
         keys = EncryptionKeysCollection([key])
         with self.assertRaises(EncryptionError):
-            encrypt_data(data, keys=keys, site_id=site_id)
+            encrypt_data(data, IdentityScope.UID2, keys=keys, site_id=site_id)
 
 
     def test_encrypt_data_site_key_expired_custom_now(self):
@@ -253,7 +330,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         now = dt.datetime.utcnow() - dt.timedelta(days=1)
         key = EncryptionKey(101, site_id, now, now, now + dt.timedelta(seconds=1), encryption_block_size * b'9')
         keys = EncryptionKeysCollection([key])
-        encrypted = encrypt_data(data, site_id=site_id, keys=keys, now=now)
+        encrypted = encrypt_data(data, IdentityScope.UID2, site_id=site_id, keys=keys, now=now)
         decrypted = decrypt_data(encrypted, keys)
         self.assertEqual(data, decrypted.data)
         self.assertEqual(format_time(now), format_time(decrypted.encrypted_at))
@@ -264,9 +341,9 @@ class TestEncryptionFunctions(unittest.TestCase):
         expiry = dt.datetime(2021, 3, 22, 9, 1, 2)
         key = _test_site_key
         keys = EncryptionKeysCollection([_master_key, key])
-        token = _encrypt_token(_uid2, _master_key, key, site_id=key.site_id, expiry=expiry)
+        token = _encrypt_token_v3(_uid2, _master_key, key, site_id=key.site_id, expiry=expiry)
         with self.assertRaises(EncryptionError):
-            encrypt_data(data, keys=keys, advertising_token=token)
+            encrypt_data(data, IdentityScope.UID2, keys=keys, advertising_token=token)
 
 
     def test_encrypt_data_expired_token_custom_now(self):
@@ -274,13 +351,13 @@ class TestEncryptionFunctions(unittest.TestCase):
         expiry = dt.datetime(2021, 3, 22, 9, 1, 2)
         key = _test_site_key
         keys = EncryptionKeysCollection([_master_key, key])
-        token = _encrypt_token(_uid2, _master_key, key, site_id=key.site_id, expiry=expiry)
+        token = _encrypt_token_v3(_uid2, _master_key, key, site_id=key.site_id, expiry=expiry)
 
         with self.assertRaises(EncryptionError):
-            encrypt_data(data, keys=keys, advertising_token=token, now=expiry+dt.timedelta(seconds=1))
+            encrypt_data(data, IdentityScope.UID2, keys=keys, advertising_token=token, now=expiry+dt.timedelta(seconds=1))
 
         now = expiry-dt.timedelta(seconds=1)
-        encrypted = encrypt_data(data, keys=keys, advertising_token=token, now=now)
+        encrypted = encrypt_data(data, IdentityScope.UID2, keys=keys, advertising_token=token, now=now)
         decrypted = decrypt_data(encrypted, keys)
         self.assertEqual(data, decrypted.data)
         self.assertEqual(format_time(now), format_time(decrypted.encrypted_at))
@@ -290,7 +367,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         data = b'123456'
         key = _test_site_key
         keys = EncryptionKeysCollection([key])
-        encrypted = encrypt_data(data, key=key)
+        encrypted = encrypt_data(data, IdentityScope.UID2, key=key)
         encrypted_bytes = base64.b64decode(encrypted)
         encrypted = base64.b64encode(bytes([0]) + encrypted_bytes[1:]).decode('ascii')
         with self.assertRaises(EncryptionError):
@@ -301,7 +378,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         data = b'123456'
         key = _test_site_key
         keys = EncryptionKeysCollection([key])
-        encrypted = encrypt_data(data, key=key)
+        encrypted = encrypt_data(data, IdentityScope.UID2, key=key)
         encrypted_bytes = base64.b64decode(encrypted)
         encrypted = base64.b64encode(encrypted_bytes[0:1] + bytes([0]) + encrypted_bytes[2:]).decode('ascii')
         with self.assertRaises(EncryptionError):
@@ -312,7 +389,7 @@ class TestEncryptionFunctions(unittest.TestCase):
         data = b'123456'
         key = _test_site_key
         keys = EncryptionKeysCollection([key])
-        encrypted = encrypt_data(data, key=key)
+        encrypted = encrypt_data(data, IdentityScope.UID2, key=key)
         encrypted_bytes = base64.b64decode(encrypted)
         encrypted = base64.b64encode(encrypted_bytes + b'1').decode('ascii')
         with self.assertRaises(EncryptionError):
@@ -326,13 +403,24 @@ class TestEncryptionFunctions(unittest.TestCase):
         data = b'123456'
         key = _test_site_key
         keys = EncryptionKeysCollection([key])
-        encrypted = encrypt_data(data, key=key)
+        encrypted = encrypt_data(data, IdentityScope.UID2, key=key)
         dkeys = EncryptionKeysCollection([_master_key])
         with self.assertRaises(EncryptionError):
             decrypt_data(encrypted, dkeys)
 
 
-def _encrypt_token(id_str, master_key, site_key, version=2, expiry=dt.timedelta(hours=1), site_id=0, privacy_bits=0):
+    def test_decrypt_data_v2(self):
+        data = b'123456'
+        now = dt.datetime.utcnow() - dt.timedelta(days=1)
+        key = _test_site_key
+        keys = EncryptionKeysCollection([key])
+        encrypted = _encrypt_data_v2(data, key=key, site_id=12345, now=now)
+        decrypted = decrypt_data(encrypted, keys)
+        self.assertEqual(data, decrypted.data)
+        self.assertEqual(format_time(now), format_time(decrypted.encrypted_at))
+
+
+def _encrypt_token_v2(id_str, master_key, site_key, version=2, expiry=dt.timedelta(hours=1), site_id=0, privacy_bits=0):
     id = bytes(id_str, 'utf-8')
     identity = int.to_bytes(site_id, 4, 'big')
     identity += int.to_bytes(len(id), 4, 'big')
@@ -351,6 +439,49 @@ def _encrypt_token(id_str, master_key, site_key, version=2, expiry=dt.timedelta(
     token += _encrypt_data_v1(master_payload, key=master_key, iv=master_iv)
 
     return base64.b64encode(token).decode('ascii')
+
+
+def _encrypt_token_v3(id_str, master_key, site_key, identity_type=0, version=112, expiry=dt.timedelta(hours=1), site_id=0, privacy_bits=0):
+    id = base64.b64decode(id_str)
+
+    site_payload = int.to_bytes(site_id, 4, 'big')
+    site_payload += int.to_bytes(0, 8, 'big')  # publisher id
+    site_payload += int.to_bytes(0, 4, 'big')  # client key id
+
+    site_payload += int.to_bytes(0, 4, 'big')  # privacy bits
+    site_payload += int.to_bytes(int((dt.datetime.utcnow() - dt.timedelta(hours=1)).timestamp()) * 1000, 8, 'big')  # established
+    site_payload += int.to_bytes(int((dt.datetime.utcnow() - dt.timedelta(hours=1)).timestamp()) * 1000, 8, 'big')  # refreshed
+    site_payload += id
+
+    if not isinstance(expiry, dt.datetime):
+        expiry = dt.datetime.utcnow() + expiry
+    master_payload = int.to_bytes(int(expiry.timestamp()) * 1000, 8, 'big')
+    master_payload += int.to_bytes(int((dt.datetime.utcnow()).timestamp()) * 1000, 8, 'big')  # created
+
+    master_payload += int.to_bytes(0, 4, 'big')  # operator site id
+    master_payload += int.to_bytes(0, 1, 'big')  # operator type
+    master_payload += int.to_bytes(0, 4, 'big')  # operator version
+    master_payload += int.to_bytes(0, 4, 'big')  # operator key id
+
+    master_payload += int.to_bytes(site_key.key_id, 4, 'big')
+    master_payload += _encrypt_gcm(site_payload, None, site_key.secret)
+
+    token = int.to_bytes(identity_type << 4, 1, 'big')
+    token += int.to_bytes(version, 1, 'big')
+    token += int.to_bytes(master_key.key_id, 4, 'big')
+    token += _encrypt_gcm(master_payload, None, master_key.secret)
+
+    return base64.b64encode(token).decode('ascii')
+
+
+def _encrypt_data_v2(data, key, site_id, now):
+    iv = os.urandom(encryption_block_size)
+    result = int.to_bytes(_PayloadType.ENCRYPTED_DATA.value, 1, 'big')
+    result += int.to_bytes(1, 1, 'big')  # version
+    result += int.to_bytes(int(now.timestamp() * 1000), 8, 'big')
+    result += int.to_bytes(site_id, 4, 'big')
+    result += _encrypt_data_v1(data, key, iv)
+    return base64.b64encode(result).decode('ascii')
 
 
 def format_time(t):

--- a/uid2_client/__init__.py
+++ b/uid2_client/__init__.py
@@ -35,3 +35,11 @@ from .auto_refresh import *
 from .client import *
 from .encryption import *
 from .keys import *
+
+from enum import Enum
+
+
+class IdentityScope(Enum):
+    """Enum for types of unified ID"""
+    UID2 = 0
+    EUID = 1

--- a/uid2_client/client.py
+++ b/uid2_client/client.py
@@ -32,9 +32,11 @@ Do not use this module directly, import through uid2_client module instead, e.g.
 import base64
 import datetime as dt
 import json
+import os
 import urllib.request as request
 
 from .keys import EncryptionKey, EncryptionKeysCollection
+from .encryption import _decrypt_gcm, _encrypt_gcm
 
 
 def _make_dt(timestamp):
@@ -44,7 +46,7 @@ def _make_dt(timestamp):
 class Uid2Client:
     """Client for interacting with UID2 services.
 
-    You will need to have the base URL of the endpoint and a client authorization key
+    You will need to have the base URL of the endpoint and a client key pair (auth/secret)
     to consume web services.
 
     Methods:
@@ -53,23 +55,25 @@ class Uid2Client:
     Examples:
         Connect to the UID2 service and obtain the latest encryption keys:
         >>> from uid2_client import *
-        >>> client = Uid2Client('https://prod.uidapi.com', 'my-authorization-key')
+        >>> client = Uid2Client('https://prod.uidapi.com', 'my-authorization-key', 'my-secret-key')
         >>> keys = client.refresh_keys()
         >>> uid2 = decrypt_token('some-ad-token', keys).uid2
     """
 
-    def __init__(self, base_url, auth_key):
+    def __init__(self, base_url, auth_key, secret_key):
         """Create a new Uid2Client client.
 
         Args:
             base_url (str): base URL for all requests to UID2 services (e.g. 'https://prod.uidapi.com')
             auth_key (str): authorization key for consuming the UID2 services
+            secret_key (str): secret key for consuming the UID2 services
 
         Note:
             Your authorization key will determine which UID2 services you are allowed to use.
         """
         self._base_url = base_url
         self._auth_key = auth_key
+        self._secret_key = base64.b64decode(secret_key)
 
 
     def refresh_keys(self):
@@ -82,9 +86,11 @@ class Uid2Client:
         Returns:
             EncryptionKeysCollection containing the keys
         """
-        resp = self._get('/v1/key/latest', headers=self._auth_headers())
+        req, nonce = self._make_v2_request(dt.datetime.utcnow())
+        print(req)
+        resp = self._post('/v2/key/latest', headers=self._auth_headers(), data=req)
         keys = [EncryptionKey(k['id'], k.get('site_id', -1), _make_dt(k['created']), _make_dt(k['activates']), _make_dt(k['expires']), base64.b64decode(k['secret']))
-            for k in json.loads(resp.read()).get('body')]
+            for k in json.loads(self._parse_v2_response(resp.read(), nonce)).get('body')]
         return EncryptionKeysCollection(keys)
 
 
@@ -96,8 +102,26 @@ class Uid2Client:
         return {'Authorization': 'Bearer ' + self._auth_key}
 
 
-    def _get(self, path, headers):
-        req = request.Request(self._make_url(path), headers=headers, method='GET')
+    def _make_v2_request(self, now):
+        payload = int.to_bytes(int(now.timestamp() * 1000), 8, 'big')
+        nonce = os.urandom(8)
+        payload += nonce
+
+        envelope = int.to_bytes(1, 1, 'big')
+        envelope += _encrypt_gcm(payload, None, self._secret_key)
+
+        return base64.b64encode(envelope), nonce
+
+
+    def _parse_v2_response(self, encrypted, nonce):
+        payload = _decrypt_gcm(base64.b64decode(encrypted), self._secret_key)
+        if nonce != payload[8:16]:
+            raise ValueError("nonce mismatch")
+        return payload[16:]
+
+
+    def _post(self, path, headers, data):
+        req = request.Request(self._make_url(path), headers=headers, method='POST', data=data)
         return request.urlopen(req)
 
 


### PR DESCRIPTION
- switch querying keys to use v2 APIs
- switch DEP blob encryption to v3 format
- add support for decrypting v3 advertising tokens and DEP blobs