### PR TITLE
[UID2-3320] Clean up dependencies and point to official guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,55 +2,6 @@
 
 The UID 2 Project is subject to Tech Lab IPR’s Policy and is managed by the IAB Tech Lab Addressability Working Group and Privacy & Rearc Commit Group. Please review [the governance rules](https://github.com/IABTechLab/uid2-core/blob/master/Software%20Development%20and%20Release%20Procedures.md).
 
-This document includes:
-* [Requirements](#requirements)
-* [Install](#install)
-* [Usage](#usage)
-* [Development](#development)
-* [Example Usage](#example-usage)
-
-## Requirements
-
-This SDK supports Python 3.6 and above.
-
-## Install
-
-The SDK can be installed using pip.
-```
-pip install uid2-client
-```
-
 ## Usage
 
 For documentation on usage, see the [UID2 SDK for Python Reference Guide](https://unifiedid.com/docs/sdks/uid2-sdk-ref-python).
-
-## Example Usage
-
-
-You can run specific examples:
-
-```
-python examples/sample_bidstream_client.py BASE_URL=https://operator-integ.uidapi.com AUTH_KEY=my-auth-key SECRET_KEY=my-secret-key
-	DOMAIN_NAME=domain-name AD_TOKEN=ad-token
-```
-
-## Development
-
-First, build the Docker image with Python 3.6 and all dev dependencies. This is required for all subsequent commands. Run the following:
-
-```
-make docker
-```
-
-Build a bdist wheel:
-
-```
-make wheel
-```
-
-Get access to an interactive shell within the Python 3.6 Docker image:
-
-```
-make shell
-```
-Run unit tests: Use PyCharm to run the test cases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.6"
 dependencies = [
+    "setuptools",
     "pycryptodome",
     "bitarray"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,14 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+requires-python = ">=3.6"
 dependencies = [
-    "pycryptodome"
+    "pycryptodome",
+    "bitarray"
 ]
-
+keywords = ["uid2"]
+[project.license]
+file="LICENSE"
 [project.urls]
 "Homepage" = "https://github.com/IABTechLab/uid2-client-python"
 "Bug Tracker" = "https://github.com/IABTechLab/uid2-client-python/issues"

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,7 @@ home_page = https://iabtechlab.com
 description = Client for working with advertising UID2 services
 long_description = file: README.md
 long_description_content_type = text/markdown
-license = Apache 2.0
-license_file = LICENSE
 platform = any
-keywords = uid2
 # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
 classifiers =
     Development Status :: 3 - Alpha
@@ -31,9 +28,6 @@ classifiers =
 zip_safe = true
 packages = find:
 include_package_data = true
-python_requires = >= 3.6
-install_requires = 
-    pycryptodome
 
 [options.packages.find]
 exclude = examples, tests


### PR DESCRIPTION
1] Moving duplicate info to official guide. uid2docs update is still WIP
2] Added package `setuptools` and `bitarray` to list of dependencies
3] Cleaned up metadata from setup.cfg file as that's the old way of package management and build was throwing warnings about them. 

Build error due to missing dependency
```
(my_venv) ➜  uid2-client-python git:(main) ✗ pip install uid2-client
Collecting uid2-client
  Using cached uid2_client-2.4.0-py3-none-any.whl.metadata (2.0 kB)
Collecting pycryptodome (from uid2-client)
  Using cached pycryptodome-3.20.0-cp35-abi3-macosx_10_9_universal2.whl.metadata (3.4 kB)
Using cached uid2_client-2.4.0-py3-none-any.whl (35 kB)
Using cached pycryptodome-3.20.0-cp35-abi3-macosx_10_9_universal2.whl (2.4 MB)
Installing collected packages: pycryptodome, uid2-client
Successfully installed pycryptodome-3.20.0 uid2-client-2.4.0
(my_venv) ➜  uid2-client-python git:(main) ✗ python3 examples/sample_identity_map_client.py https://operator-integ.uidapi.com <API_KEY> <SECRET> asloob@example.com
Traceback (most recent call last):
  File "/Users/asloob.qureshi/work/workspace/test-python/uid2-client-python/examples/sample_identity_map_client.py", line 3, in <module>
    from uid2_client import IdentityMapClient, IdentityMapInput
  File "/Users/asloob.qureshi/work/workspace/test-python/uid2-client-python/my_venv/lib/python3.10/site-packages/uid2_client/__init__.py", line 12, in <module>
    from .client import *
  File "/Users/asloob.qureshi/work/workspace/test-python/uid2-client-python/my_venv/lib/python3.10/site-packages/uid2_client/client.py", line 10, in <module>
    from .encryption import *
  File "/Users/asloob.qureshi/work/workspace/test-python/uid2-client-python/my_venv/lib/python3.10/site-packages/uid2_client/encryption.py", line 9, in <module>
    from bitarray import bitarray
ModuleNotFoundError: No module named 'bitarray'
```

Build Warnings:
```
* Getting build dependencies for sdist...
/private/var/folders/86/w50mq9fn1wn60dhjjxkhgjnc0000gq/T/build-env-ot1kp0cy/lib/python3.10/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
!!

        ********************************************************************************
        The license_file parameter is deprecated, use license_files instead.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!
  parsed = self.parsers.get(option_name, lambda x: x)(value)
/private/var/folders/86/w50mq9fn1wn60dhjjxkhgjnc0000gq/T/build-env-ot1kp0cy/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:73: _WouldIgnoreField: `requires-python` defined outside of `pyproject.toml` would be ignored.
!!

        ********************************************************************************
        ##########################################################################
        # configuration would be ignored/result in error due to `pyproject.toml` #
        ##########################################################################

        The following seems to be defined outside of `pyproject.toml`:

        `requires-python = <SpecifierSet('>=3.6')>`

        According to the spec (see the link below), however, setuptools CANNOT
        consider this value unless `requires-python` is listed as `dynamic`.

        https://packaging.python.org/en/latest/specifications/declaring-project-metadata/

        For the time being, `setuptools` will still consider the given value (as a
        **transitional** measure), but please note that future releases of setuptools will
        follow strictly the standard.

        To prevent this warning, you can list `requires-python` under `dynamic` or alternatively
        remove the `[project]` table from your file and rely entirely on other means of
        configuration.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.
        ********************************************************************************

!!
  _handle_missing_dynamic(dist, project_table)
/private/var/folders/86/w50mq9fn1wn60dhjjxkhgjnc0000gq/T/build-env-ot1kp0cy/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:73: _WouldIgnoreField: `license` defined outside of `pyproject.toml` would be ignored.
!!

        ********************************************************************************
        ##########################################################################
        # configuration would be ignored/result in error due to `pyproject.toml` #
        ##########################################################################

        The following seems to be defined outside of `pyproject.toml`:

        `license = 'Apache 2.0'`

        According to the spec (see the link below), however, setuptools CANNOT
        consider this value unless `license` is listed as `dynamic`.

        https://packaging.python.org/en/latest/specifications/declaring-project-metadata/

        For the time being, `setuptools` will still consider the given value (as a
        **transitional** measure), but please note that future releases of setuptools will
        follow strictly the standard.

        To prevent this warning, you can list `license` under `dynamic` or alternatively
        remove the `[project]` table from your file and rely entirely on other means of
        configuration.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.
        ********************************************************************************

!!
  _handle_missing_dynamic(dist, project_table)
/private/var/folders/86/w50mq9fn1wn60dhjjxkhgjnc0000gq/T/build-env-ot1kp0cy/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:73: _WouldIgnoreField: `keywords` defined outside of `pyproject.toml` would be ignored.
!!

        ********************************************************************************
        ##########################################################################
        # configuration would be ignored/result in error due to `pyproject.toml` #
        ##########################################################################

        The following seems to be defined outside of `pyproject.toml`:

        `keywords = ['uid2']`

        According to the spec (see the link below), however, setuptools CANNOT
        consider this value unless `keywords` is listed as `dynamic`.

        https://packaging.python.org/en/latest/specifications/declaring-project-metadata/

        For the time being, `setuptools` will still consider the given value (as a
        **transitional** measure), but please note that future releases of setuptools will
        follow strictly the standard.

        To prevent this warning, you can list `keywords` under `dynamic` or alternatively
        remove the `[project]` table from your file and rely entirely on other means of
        configuration.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.
        ********************************************************************************

!!
```