### PR TITLE
add requirements.txt for building client and running examples

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+bitarray==3.8.0
+pycryptodome==3.23.0
+typing_extensions==4.15.0


### PR DESCRIPTION
Add requirements.txt for building client and running examples. Tested on python3.12