### PR TITLE
UID2-6793: Pin external GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -26,10 +26,10 @@ jobs:
         python-version: ["3.10","3.11","3.12","3.13"]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: ${{ matrix.python-version }}
     

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,10 +15,10 @@ jobs:
         python-version: ["3.10","3.11","3.12","3.13"]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: ${{ matrix.python-version }}
     


### PR DESCRIPTION
## Summary
- Pin all third-party GitHub Action references to full-length commit SHAs for supply chain security
- Internal IABTechLab reusable workflows and composite actions remain tag-pinned

## Test plan
- [ ] Verify CI workflows pass on this branch
- [ ] Spot-check that IABTechLab shared action references still have correct subpaths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of [UID2-6793](https://thetradedesk.atlassian.net/browse/UID2-6793)