### PR TITLE
UID2-6799 Use 'ci-auto-merge' environment

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -50,4 +50,5 @@ jobs:
       release_type: ${{ inputs.release_type }}
       publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
       vulnerability_failure_severity: ${{ inputs.vulnerability_failure_severity }}
+      merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     secrets: inherit


### PR DESCRIPTION
## Summary
Pass `merge_environment: 'ci-auto-merge'` on protected branches so the release workflow uses the UID2SourceAdmin PAT to bypass the PR review ruleset when auto-merging the version bump PR.